### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=1.0.0
 author=Pershin Sergey <x029ah@gmail.com>
 maintainer=Pershin Sergey <x029ah@gmail.com>
 sentence=A library to control 7-segment displays using SPI and 74hc595/74hc4094 shift registers
+paragraph=It has customizable output pattern (default is Q0=A, Q1=B, .. , Q6=G, Q7=.)
 category=Display
 url=https://github.com/029ah/z7seg_led/
 architectures=*


### PR DESCRIPTION
When the paragraph field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format