### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,18 +12,18 @@ z7seg_led	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-z7seg_led_74hc595   KEYWORD2
-z7seg_led_74hc4094  KEYWORD2
-begin               KEYWORD2
-set_pattern         KEYWORD2
-set_brightness      KEYWORD2
-print               KEYWORD2
-begin_transfer      KEYWORD2
-end_transfer        KEYWORD2
-send_digit          KEYWORD2
-send_char           KEYWORD2
-send_digit          KEYWORD2
-send_char           KEYWORD2
+z7seg_led_74hc595	KEYWORD2
+z7seg_led_74hc4094	KEYWORD2
+begin	KEYWORD2
+set_pattern	KEYWORD2
+set_brightness	KEYWORD2
+print	KEYWORD2
+begin_transfer	KEYWORD2
+end_transfer	KEYWORD2
+send_digit	KEYWORD2
+send_char	KEYWORD2
+send_digit	KEYWORD2
+send_char	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords